### PR TITLE
fix locale warnings

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -31,7 +31,8 @@ RUN echo "deb ${DEB_MIRROR} buster main" > /etc/apt/sources.list \
     geoip-database \
     geoip-database-extra
 
-RUN locale-gen en_US.UTF-8 # Fix locale errors
+# Fix locale errors
+RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 
 #
 # Install Docker CE CLI

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,7 @@ dmypy.json
 
 # IDEs
 .idea/
+
+# Debian package
+*.tar.gz
+deb_dist/


### PR DESCRIPTION
It looks locale warnings is not fixed yet. I have been getting

```
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
	LANGUAGE = (unset),
	LC_ALL = (unset),
	LANG = "en_US.utf8"
```

when I build .deb package by `python3 setup.py --command-packages=stdeb.command bdist_deb`