### PR TITLE
fix(devcontainer): override config values

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -81,9 +81,3 @@ RUN pip3 install -r requirements.txt
 COPY setup.py .
 COPY ./c8ydm ./c8ydm
 RUN pip3 install .
-
-COPY ./scripts ./scripts
-RUN ./scripts/generate_cert.sh \
-    --serial pyagent0001 \
-    --root-name iot-ca \
-    --cert-dir /root/.cumulocity/certs

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -62,5 +62,5 @@
 
 	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
 	// "remoteUser": "vscode"
-	"postAttachCommand": "service ssh start && c8ydm.start"
+	"postAttachCommand": "scripts/start_devcontainer.sh"
 }

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ In the background the Agent will be build and started. Also a debug/run configur
 
 ### Using certificate authentication
 
-The container is built along with certificates, which are placed at `/root/.cumulocity/certs`. 
+The container generates certificates when it starts, which are placed at `/root/.cumulocity/certs`. 
 You can add the generated root certificate to your tenant's trusted certificate list by executing the script like below:
 
 ```
@@ -159,7 +159,7 @@ You can add the generated root certificate to your tenant's trusted certificate 
 --cert-name <(arbitrary) displayed name of the root certificate>
 ```
 
-After this, you can connect the agent to your tenant using cert authentication (with the serial `pyagent0001`).
+After this, you can connect the agent to your tenant using cert authentication.
 
 ## Extending the agent
 

--- a/config/agent.ini
+++ b/config/agent.ini
@@ -7,7 +7,7 @@ c8y.bootstrap.password = Fhdt1bb1f
 url = mqtt.eu-latest.cumulocity.com
 port = 8883
 tls = true
-cert_auth = false
+cert_auth = true
 client_cert = s7y_pi.crt
 client_key = s7y_pi.key
 cacert = /etc/ssl/certs/ca-certificates.crt
@@ -15,6 +15,7 @@ ping.interval.seconds = 60
 
 [agent]
 name = dm-example-device
+device.id = external_id
 type = c8y_dm_example_device
 main.loop.interval.seconds = 10
 requiredinterval = 10

--- a/scripts/start_devcontainer.sh
+++ b/scripts/start_devcontainer.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+CERT_DIR="/root/.cumulocity/certs"
+CONFIG_FILE="/root/.cumulocity/agent.ini"
+
+scripts/generate_cert.sh \
+    --serial $HOSTNAME \
+    --root-name iot-ca \
+    --cert-dir $CERT_DIR
+
+# todo read config from environment variables and upload cert here
+
+# escape forward slash for sed
+CERT_DIR_ESCAPED=$(echo "$CERT_DIR" | sed 's/\//\\\//g')
+
+cacert="$CERT_DIR_ESCAPED\/iot-ca.pem"
+client_cert="$CERT_DIR_ESCAPED\/chain-$HOSTNAME.pem"
+client_key="$CERT_DIR_ESCAPED\/$HOSTNAME-private-key.pem"
+
+sed -i "s/^\(device\.id\s*=\s*\).*\$/\1$HOSTNAME/" $CONFIG_FILE
+sed -i "s/^\(cacert\s*=\s*\).*\$/\1$cacert/" $CONFIG_FILE
+sed -i "s/^\(client_cert\s*=\s*\).*\$/\1$client_cert/" $CONFIG_FILE
+sed -i "s/^\(client_key\s*=\s*\).*\$/\1$client_key/" $CONFIG_FILE
+
+service ssh start


### PR DESCRIPTION
https://github.com/SoftwareAG/cumulocity-devicemanagement-agent/issues/25#issuecomment-915094898

Instead of updating agent.ini, I modified devcontainer settings to override config values. This is because a serial and filenames for certs are determined after creation of the container.