### PR TITLE
read environment variables into config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -83,7 +83,3 @@ COPY ./c8ydm ./c8ydm
 RUN pip3 install .
 
 COPY ./scripts ./scripts
-RUN ./scripts/generate_cert.sh \
-    --serial pyagent0001 \
-    --root-name iot-ca \
-    --cert-dir /root/.cumulocity/certs

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -62,5 +62,5 @@
 
 	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
 	// "remoteUser": "vscode"
-	"postAttachCommand": "service ssh start && c8ydm.start"
+	"postAttachCommand": "service ssh start"
 }

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ To quickly run the agent just make sure that Docker is installed on your compute
 in a console of your choice. The script will build a docker image and starting one instance afterwards.
 When bootstrapping is used the docker container Id is the device Id which should be entered when registering a device in cumulocity.
 
+To connect to your own tenant, run
+
+```
+C8YDM_MQTT_URL=<tenant domain> \
+C8YDM_SECRET_C8Y__BOOTSTRAP__TENANT=<tenant ID> \
+C8YDM_SECRET_C8Y__BOOTSTRAP__USER=<username used for bootstrapping> \
+C8YDM_SECRET_C8Y__BOOTSTRAP__PASSWORD=<password used for bootstrapping> \
+./start.sh
+```
+
 If you don't want to run within docker follow the steps below.
 
 # Configuration
@@ -54,6 +64,16 @@ loglevel = INFO
 | agent    | main.loop.interval.seconds | The interval in seconds sensor data will be forwarded to Cumulocity
 | agent    | requiredinterval | The interval in minutes for Cumulocity to detect that the device is online/offline.
 | agent    | loglevel   | The log level to write and print to file/console. 
+
+## Environment variables
+
+The environment variables which with C8YDM_ prefix are mapped to configuration files.
+Mapping rules:
+
+  - Prefix C8YDM_<PREFIX>_ means what section the option belongs to
+  - Upper case letters are mapped to lower case letters
+  - Double underscore __ is mapped to .
+
 # Build
 
 The agent can be build in multiple ways.
@@ -146,10 +166,15 @@ In the background the Agent will be build and started. Also a debug/run configur
 
 ### Using certificate authentication
 
-The container is built along with certificates, which are placed at `/root/.cumulocity/certs`. 
-You can add the generated root certificate to your tenant's trusted certificate list by executing the script like below:
+You can generate certificates necessary to certficate authentication, and you can upload the generated root certificate o your tenant's trusted certificate list by executing the scripts like below:
 
 ```
+./scripts/generate_cert.sh \
+--serial pyagent0001 \
+--root-name iot-ca \
+--cert-dir /root/.cumulocity/certs \
+--cert-name device-cert
+
 ./scripts/upload_cert.sh \
 --tenant-domain <tenant domain> \
 --tenant-id <tenant ID> \
@@ -159,7 +184,7 @@ You can add the generated root certificate to your tenant's trusted certificate 
 --cert-name <(arbitrary) displayed name of the root certificate>
 ```
 
-After this, you can connect the agent to your tenant using cert authentication (with the serial `pyagent0001`).
+After this, you can connect the agent to your tenant using cert authentication (with the serial `pyagent0001` in this case).
 
 ## Extending the agent
 

--- a/c8ydm/client/mqtt_agent.py
+++ b/c8ydm/client/mqtt_agent.py
@@ -306,7 +306,7 @@ class Agent():
             self.logger.debug('Received: topic=%s msg=%s',
                           message.topic, message.getMessage())
             if message.messageId == '71':
-                self.token = message.values
+                self.token = message.values[0]
                 self.logger.info('New JWT Token received')
             for listener in self.__listeners:
                 self.logger.debug('Trigger listener ' +

--- a/config/agent.ini
+++ b/config/agent.ini
@@ -2,9 +2,6 @@
 c8y.bootstrap.tenant = management
 c8y.bootstrap.user = devicebootstrap
 c8y.bootstrap.password = Fhdt1bb1f
-c8y.tenant = subtenant
-c8y.username = user
-c8y.password = pass
 
 [mqtt]
 url = mqtt.eu-latest.cumulocity.com
@@ -17,7 +14,6 @@ cacert = /etc/ssl/certs/ca-certificates.crt
 ping.interval.seconds = 60
 
 [agent]
-device.id = externalid
 name = dm-example-device
 type = c8y_dm_example_device
 main.loop.interval.seconds = 10

--- a/config/agent.ini
+++ b/config/agent.ini
@@ -2,18 +2,22 @@
 c8y.bootstrap.tenant = management
 c8y.bootstrap.user = devicebootstrap
 c8y.bootstrap.password = Fhdt1bb1f
+c8y.tenant = subtenant
+c8y.username = user
+c8y.password = pass
 
 [mqtt]
 url = mqtt.eu-latest.cumulocity.com
 port = 8883
 tls = true
 cert_auth = false
-client_cert = s7y_pi.crt
-client_key = s7y_pi.key
+client_cert = /root/.cumulocity/certs/chain-cert.pem
+client_key = /root/.cumulocity/certs/device-cert-private-key.pem
 cacert = /etc/ssl/certs/ca-certificates.crt
 ping.interval.seconds = 60
 
 [agent]
+device.id = externalid
 name = dm-example-device
 type = c8y_dm_example_device
 main.loop.interval.seconds = 10

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -89,4 +89,6 @@ RUN apt-get -y --purge autoremove \
     python3-stdeb \
     python3-setuptools
 
-CMD service ssh start && exec c8ydm.start
+COPY ./scripts ./scripts
+
+CMD scripts/start_docker.sh

--- a/scripts/start_docker.sh
+++ b/scripts/start_docker.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -euo pipefail
+
+CA_NAME="iot-ca"
+CERT_NAME="device-cert"
+
+if [ -n $C8YDM_MQTT_CERT_AUTH ] && [ $C8YDM_MQTT_CERT_AUTH = "true" ]; then
+    # use container id as serial
+    ./scripts/generate_cert.sh \
+    --serial $HOSTNAME \
+    --root-name $CA_NAME \
+    --cert-name $CERT_NAME \
+    --cert-dir "/root/.cumulocity/certs"
+
+    ./scripts/upload_cert.sh \
+    --tenant-domain $C8YDM_MQTT_URL \
+    --tenant-id $C8YDM_SECRET_C8Y__BOOTSTRAP__TENANT \
+    --username $C8YDM_SECRET_C8Y__BOOTSTRAP__USER \
+    --password $C8YDM_SECRET_C8Y__BOOTSTRAP__PASSWORD \
+    --cert-path "/root/.cumulocity/certs/$CA_NAME.pem" \
+    --cert-name $CA_NAME
+
+    export C8YDM_AGENT_DEVICE__ID=$HOSTNAME
+fi
+
+service ssh start && exec c8ydm.start

--- a/scripts/start_docker.sh
+++ b/scripts/start_docker.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 CA_NAME="iot-ca"
 CERT_NAME="device-cert"
 
-if [ -n $C8YDM_MQTT_CERT_AUTH ] && [ $C8YDM_MQTT_CERT_AUTH = "true" ]; then
+if [ -n "${C8YDM_MQTT_CERT_AUTH:-}" ] && [ $C8YDM_MQTT_CERT_AUTH = "true" ]; then
     # use container id as serial
     ./scripts/generate_cert.sh \
     --serial $HOSTNAME \

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 docker build -t dm-image -f docker/Dockerfile .
-docker run -d -v /var/run/docker.sock:/var/run/docker.sock dm-image
+# load variables starting with "C8YDM"
+docker run --env-file <(env | grep C8YDM) \
+           -d -v /var/run/docker.sock:/var/run/docker.sock dm-image


### PR DESCRIPTION
https://github.com/SoftwareAG/cumulocity-devicemanagement-agent/issues/25#issuecomment-915094898

Basically this change will help you start docker container (`start.sh`) with config modified for given tenant:

```
C8YDM_MQTT_URL=<tenant domain> \
C8YDM_MQTT_CERT_AUTH=true \
C8YDM_SECRET_C8Y__BOOTSTRAP__TENANT=<tenant id> \
C8YDM_SECRET_C8Y__BOOTSTRAP__USER=<tenant username> \
C8YDM_SECRET_C8Y__BOOTSTRAP__PASSWORD=<tenant password> \
C8YDM_SECRET_C8Y__TENANT=<subtenant id> \
C8YDM_SECRET_C8Y__USERNAME=<subtenant username> \
C8YDM_SECRET_C8Y__PASSWORD=<subtenant password> \
./start.sh
```

By executing this, certificates will be generated and the root ca is uploaded to your tenant, then the agent will connect to the tenant with cert authentication.