### PR TITLE
small changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ If you want to use Cloud Remote Access with a VNC server, you can install the se
 INSTALL_VNC=1 ./start.sh
 ```
 
+By default, the docker container runs in background. If you want to run it interactively:
+
+```
+INTERACTIVE=1 ./start.sh
+```
+
 If you don't want to run within docker follow the steps below.
 
 # Configuration

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,7 @@
 FROM debian:10-slim
-ARG DEB_MIRROR=http://ftp.de.debian.org/debian
-ARG INSTALL_VNC=0
 
 # Install additional packages.
+ARG DEB_MIRROR=http://ftp.de.debian.org/debian
 ENV DEBIAN_FRONTEND=noninteractive
 ENV CONTAINER=docker
 RUN echo "deb ${DEB_MIRROR} buster main" > /etc/apt/sources.list \
@@ -50,6 +49,7 @@ RUN apt-get update \
     && chmod +x /usr/local/bin/docker-compose
 
 # Install VNC server and desktop environment
+ARG INSTALL_VNC=0
 RUN if [ "$INSTALL_VNC" = "1" ]; then \
         apt-get -y install \
         xfce4 \
@@ -84,23 +84,26 @@ COPY ./c8ydm ./c8ydm
 RUN pip3 install .
 
 # Clean up unnecessary packages
-RUN apt-get -y --purge autoremove \
-    git \
-    build-essential \
-    debhelper \
-    dh-python \
-    python-docutils \
-    python-sphinx \
-    fakeroot \
-    bash-completion \
-    locales \
-    aptly \
-    python3-all \
-    python3-pip \
-    python3-dev \
-    python3-wheel \
-    python3-stdeb \
-    python3-setuptools
+ARG CLEAN_PACKAGES=1
+RUN if [ "$CLEAN_PACKAGES" = "1" ]; then \
+        apt-get -y --purge autoremove \
+        git \
+        build-essential \
+        debhelper \
+        dh-python \
+        python-docutils \
+        python-sphinx \
+        fakeroot \
+        bash-completion \
+        locales \
+        aptly \
+        python3-all \
+        python3-pip \
+        python3-dev \
+        python3-wheel \
+        python3-stdeb \
+        python3-setuptools; \
+    fi
 
 COPY ./scripts ./scripts
 

--- a/start.sh
+++ b/start.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 DOCKER_FILE_PATH=docker/Dockerfile
+DOCKER_IMAGE_NAME=c8ydm-image
+DOCKER_CONTAINER_NAME=c8ydm
 # construct build args from env
 function env_build_arg() {
-    BUILD_ARG_LIST=$(grep -oP '^ARG .*(?==)' docker/Dockerfile | cut -d' ' -f2-)
+    BUILD_ARG_LIST=$(grep -oP '^ARG .*(?==)' "$DOCKER_FILE_PATH" | cut -d' ' -f2-)
     BUILD_ARG_ARG=''
     for BUILD_ARG in $BUILD_ARG_LIST
     do
@@ -14,7 +16,14 @@ function env_build_arg() {
     done
     echo $BUILD_ARG_ARG
 }
-docker build -t dm-image -f "$DOCKER_FILE_PATH" $(env_build_arg) .
+docker build -t $DOCKER_IMAGE_NAME -f "$DOCKER_FILE_PATH" $(env_build_arg) .
+# check interactivity
+INTERACTIVITY_ARG='-d'
+if [ "${INTERACTIVE:-}" = 1 ]
+then
+    INTERACTIVITY_ARG='-it'
+fi
 # load variables starting with "C8YDM"
 docker run --env-file <(env | grep C8YDM) \
-           -d -v /var/run/docker.sock:/var/run/docker.sock dm-image
+           --name $DOCKER_CONTAINER_NAME --rm $INTERACTIVITY_ARG \
+           -v /var/run/docker.sock:/var/run/docker.sock $DOCKER_IMAGE_NAME


### PR DESCRIPTION
I made some changes.

1. added INTERACTIVE docker arg to execute docker interactively optionally. This is useful when you want to see logs immediately. I also added readme.
2. fix start.sh to use DOCKER_FILE_PATH, which is introduced previous commit.
3. added container name and `--rm` parameter on docker launch of start.sh. Container name is useful when you kill docker container and `--rm` option makes killing container remove container so that you can restart immediately.
4. added CLEAN_PACKAGES docker arg to save container build time optionally. It's useful when you debug c8ydm code. It's not documented because it's for contributing purpose only ;)
5. Define docker args immediately before usage. This makes docker layer caches exist as long as you expect.

Sample usage:

```
CLEAN_PACKAGES=0 INTERACTIVE=1 DEB_MIRROR=http://ftp.jp.debian.org/debian INSTALL_VNC=1 sudo -E bash ./start.sh
```
